### PR TITLE
Refresh expired access tokens automatically

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,3 +18,5 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+**/*.d.ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "inlineSources": true,
     "baseUrl": ".",
     "module": "es6",
+    "esModuleInterop": true,
     "experimentalDecorators": true,
     "skipLibCheck": true,
     "paths": {

--- a/types/dummy/index.d.ts
+++ b/types/dummy/index.d.ts
@@ -1,1 +1,6 @@
+declare module 'ember-concurrency' {
+  function timeout(ms: number): void;
 
+  export default { timeout };
+  export = { timeout };
+}


### PR DESCRIPTION
This PR:

* Adds a `refreshAccessToken()` method on the cognito service
* Setups up a task to automatically call this method every 45, to prevent the access token from expiring in the background