### PR TITLE
fix: Remove duplicate lib inclusion

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,4 @@
 'use strict';
-const path = require('path');
-const MergeTrees = require('broccoli-merge-trees');
-const Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: require('./package').name,
@@ -24,30 +21,5 @@ module.exports = {
     }
 
     this._super.included.apply(this, arguments);
-  },
-
-  treeForVendor(vendorTree) {
-    let amazonCognitoIdentityJsPath = this._getPath();
-
-    let trees = [];
-    if (vendorTree) {
-      trees.push(vendorTree);
-    }
-
-    let amazonCognitoIdentityJsTree = new Funnel(amazonCognitoIdentityJsPath, {
-      destDir: 'amazon-cognito-identity-js',
-    });
-
-    trees.push(amazonCognitoIdentityJsTree);
-
-    return new MergeTrees(trees, { overwrite: true });
-  },
-
-  _getPath() {
-    let basePath = path.dirname(require.resolve('amazon-cognito-identity-js'));
-
-    // The path returned here is e.g. node_modules/amazon-cognito-identity-js/lib
-    // We want to move one step out to get the dist folder
-    return basePath.replace('/lib', '/dist').replace('\\lib', '\\dist');
   },
 };

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
     "@glimmer/tracking": "^1.0.0",
     "@types/amazon-cognito-auth-js": "^1.2.2",
     "amazon-cognito-identity-js": "^4.2.1",
-    "broccoli-funnel": "^3.0.2",
-    "broccoli-merge-trees": "^4.2.0",
     "ember-auto-import": "^1.5.3",
     "ember-cli-babel": "^7.19.0",
     "ember-cli-htmlbars": "^4.3.1",


### PR DESCRIPTION
This was forgotten to remove when we moved to use ember-auto-import.