### PR TITLE
feat: Drop `onAuthenticated()` and `onUnauthenticated()` hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,9 @@ Call this (and wait for it to complete) in your application route!
 Try to login with the given username & password.
 Will reject with an Error, or resolve if successfull.
 
-Triggers `onAuthenticated()` on the cognito-service,
-which by default redirects to `afterLoginRoute` (`index`, by default).
-
 ### logout()
 
 Log out the user from the current device.
-
-Triggers `onUnauthenticated()` on the cognito-service,
-which by default redirects to `loginRoute` (`login`, by default).
 
 ### invalidateAccessTokens()
 

--- a/addon/services/cognito.ts
+++ b/addon/services/cognito.ts
@@ -34,11 +34,6 @@ export type UserAttributes = { [key: string]: any };
 export default class CognitoService extends Service {
   @service router: RouterService;
 
-  // Overwrite if necessary
-  loginRoute: string = 'login';
-  resetPasswordRoute: string = 'reset-password';
-  afterLoginRoute: string = 'index';
-
   // Overwrite for testing
   _cognitoStorage: undefined | ICognitoStorage;
 
@@ -95,18 +90,6 @@ export default class CognitoService extends Service {
     this._userPool = new CognitoUserPool(poolData);
     return this._userPool;
   }
-
-  // Hooks begin
-
-  // eslint-disable-next-line no-unused-vars
-  onAuthenticated() {
-    this.router.transitionTo(this.afterLoginRoute);
-  }
-
-  onUnauthenticated() {
-    this.router.transitionTo(this.loginRoute);
-  }
-  // Hooks end
 
   // This should be called in application route, before everything else
   restoreAndLoad(): Promise<any> {
@@ -218,7 +201,6 @@ export default class CognitoService extends Service {
 
     await this._authenticate({ username, password });
     await this.restoreAndLoad();
-    await this.onAuthenticated();
 
     return this.cognitoData!;
   }
@@ -286,8 +268,6 @@ export default class CognitoService extends Service {
       // @ts-ignore next-line
       this._debouncedRefreshAccessToken.cancelAll();
     }
-
-    this.onUnauthenticated();
   }
 
   invalidateAccessTokens(): Promise<any> {
@@ -298,7 +278,6 @@ export default class CognitoService extends Service {
 
       this.cognitoData.cognitoUser.globalSignOut({
         onSuccess: () => {
-          this.onUnauthenticated();
           resolve();
         },
 

--- a/tests/dummy/app/components/cognito-login-form.ts
+++ b/tests/dummy/app/components/cognito-login-form.ts
@@ -63,7 +63,10 @@ export default class CognitoLoginForm extends Component {
       }
 
       this.error = error;
+      return;
     }
+
+    this.router.transitionTo('index');
   }
 
   // This can be overwritten

--- a/tests/dummy/app/components/cognito-reset-password-form.ts
+++ b/tests/dummy/app/components/cognito-reset-password-form.ts
@@ -85,7 +85,7 @@ export default class CognitoResetPasswordForm extends Component<Args> {
       return;
     }
 
-    this.router.transitionTo(this.cognito.afterLoginRoute);
+    this.router.transitionTo('index');
   }
 
   @action

--- a/tests/dummy/app/index/controller.js
+++ b/tests/dummy/app/index/controller.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 
 export default class IndexController extends Controller {
   @service cognito;
+  @service router;
 
   get jwtToken() {
     return this.cognito.cognitoData.jwtToken;
@@ -12,5 +13,6 @@ export default class IndexController extends Controller {
   @action
   logout() {
     this.cognito.logout();
+    this.router.transitionTo('login');
   }
 }

--- a/tests/unit/services/cognito-test.js
+++ b/tests/unit/services/cognito-test.js
@@ -41,7 +41,6 @@ module('Unit | Service | cognito', function (hooks) {
       });
 
       this.service = this.owner.lookup('service:cognito');
-      this.service.onAuthenticated = () => {};
 
       await this.service.authenticate({
         username: 'johnwick@thecontinental.assassins',
@@ -147,7 +146,6 @@ module('Unit | Service | cognito', function (hooks) {
       });
 
       this.service = this.owner.lookup('service:cognito');
-      this.service.onAuthenticated = () => {};
 
       await this.service.authenticate({
         username: 'johnwick@thecontinental.assassins',


### PR DESCRIPTION
Instead, you can do this manually after calling `cognito.authenticate()` and `cognito.logout()` yourself. No need to extend the service!