### PR TITLE
Refactor cognito methods into util functions

### DIFF
--- a/addon-test-support/pretender/login.js
+++ b/addon-test-support/pretender/login.js
@@ -105,7 +105,7 @@ export function setupPretenderNeedsInitialPassword(
         ChallengeName: 'NEW_PASSWORD_REQUIRED',
         ChallengeParameters: {
           requiredAttributes: '[]',
-          userAttributes: `{"email_verified":"true","email":"${username}"}'`,
+          userAttributes: `{"email_verified":"true","email":"${username}"}`,
         },
 
         Session: 'TEST-SESSION-ID',

--- a/addon/services/cognito.ts
+++ b/addon/services/cognito.ts
@@ -125,8 +125,7 @@ export default class CognitoService extends Service {
       });
     });
 
-    waitForPromise(promise);
-    return promise;
+    return waitForPromise(promise);
   }
 
   async _loadUserDataAndAccessToken(): Promise<CognitoData | null> {
@@ -193,8 +192,7 @@ export default class CognitoService extends Service {
       }
     );
 
-    waitForPromise(promise);
-    return promise;
+    return waitForPromise(promise);
   }
 
   async authenticate({
@@ -278,8 +276,7 @@ export default class CognitoService extends Service {
       });
     });
 
-    waitForPromise(promise);
-    return promise;
+    return waitForPromise(promise);
   }
 
   logout(): void {
@@ -308,8 +305,7 @@ export default class CognitoService extends Service {
       });
     });
 
-    waitForPromise(promise);
-    return promise;
+    return waitForPromise(promise);
   }
 
   triggerResetPasswordMail({ username }: { username: string }): Promise<any> {
@@ -327,8 +323,7 @@ export default class CognitoService extends Service {
       });
     });
 
-    waitForPromise(promise);
-    return promise;
+    return waitForPromise(promise);
   }
 
   /*
@@ -365,8 +360,7 @@ export default class CognitoService extends Service {
       });
     });
 
-    waitForPromise(promise);
-    return promise;
+    return waitForPromise(promise);
   }
 
   /*
@@ -406,8 +400,7 @@ export default class CognitoService extends Service {
       );
     });
 
-    waitForPromise(promise);
-    return promise;
+    return waitForPromise(promise);
   }
 
   updatePassword({
@@ -434,8 +427,7 @@ export default class CognitoService extends Service {
       });
     });
 
-    waitForPromise(promise);
-    return promise;
+    return waitForPromise(promise);
   }
 
   updateAttributes(attributes: { [index: string]: string }): Promise<any> {
@@ -473,8 +465,7 @@ export default class CognitoService extends Service {
       );
     });
 
-    waitForPromise(promise);
-    return promise;
+    return waitForPromise(promise);
   }
 
   @restartableTask

--- a/addon/services/cognito.ts
+++ b/addon/services/cognito.ts
@@ -23,6 +23,7 @@ import { getUserAttributes } from 'ember-cognito-identity/utils/get-user-attribu
 import { loadUserDataAndAccessToken } from 'ember-cognito-identity/utils/load-user-data-and-access-token';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
+import { isTesting } from '@embroider/macros';
 
 export interface CognitoData {
   cognitoUser: CognitoUser;
@@ -50,13 +51,8 @@ export default class CognitoService extends Service {
     return config.cognito;
   }
 
-  get isTesting() {
-    let config = getOwner(this).resolveRegistration('config:environment');
-    return config.environment === 'test';
-  }
-
   get shouldAutoRefresh() {
-    return !this.isTesting;
+    return !isTesting();
   }
 
   autoRefreshInterval = 1000 * 60 * 45; // Tokens expire after 1h, so we refresh them every 45 minutes, to have a bit of leeway

--- a/addon/utils/cognito/authenticate-user.ts
+++ b/addon/utils/cognito/authenticate-user.ts
@@ -1,0 +1,52 @@
+import { waitForPromise } from '@ember/test-waiters';
+import { AuthenticationDetails, CognitoUser } from 'amazon-cognito-identity-js';
+import {
+  dispatchError,
+  NewPasswordRequiredError,
+} from 'ember-cognito-identity/errors/cognito';
+import { Promise as RSVPPromise } from 'rsvp';
+
+/*
+    Might reject with:
+    * InvalidAuthorizationError (username/password wrong)
+    * NewPasswordRequiredError (new user)
+    * PasswordResetRequiredError (password reset required by admin)
+   */
+export function authenticateUser(
+  cognitoUser: CognitoUser,
+  {
+    username,
+    password,
+  }: {
+    username: string;
+    password: string;
+  }
+): Promise<CognitoUser> {
+  let authenticationData = {
+    Username: username,
+    Password: password,
+  };
+  let authenticationDetails = new AuthenticationDetails(authenticationData);
+
+  let promise: Promise<CognitoUser> = new RSVPPromise((resolve, reject) => {
+    cognitoUser.authenticateUser(authenticationDetails, {
+      onSuccess() {
+        resolve(cognitoUser);
+      },
+
+      newPasswordRequired(userAttributes, requiredAttributes) {
+        reject(
+          new NewPasswordRequiredError(userAttributes, requiredAttributes)
+        );
+      },
+
+      // TODO: MFA ?
+
+      onFailure(err) {
+        reject(dispatchError(err));
+      },
+    });
+  });
+
+  return waitForPromise(promise);
+}

--- a/addon/utils/cognito/get-user-data.ts
+++ b/addon/utils/cognito/get-user-data.ts
@@ -21,19 +21,3 @@ export function getUserData(
 
   return waitForPromise(promise);
 }
-
-export async function getUserAttributes(
-  cognitoUser: CognitoUser
-): Promise<any> {
-  let userData = await getUserData(cognitoUser);
-
-  let userAttributes: { [index: string]: string } = {};
-  userData.UserAttributes.forEach((cognitoUserAttribute) => {
-    let name = cognitoUserAttribute.Name;
-    let value = cognitoUserAttribute.Value;
-
-    userAttributes[name] = value;
-  });
-
-  return userAttributes;
-}

--- a/addon/utils/cognito/get-user-session.ts
+++ b/addon/utils/cognito/get-user-session.ts
@@ -1,0 +1,33 @@
+import { waitForPromise } from '@ember/test-waiters';
+import { CognitoUser, CognitoUserSession } from 'amazon-cognito-identity-js';
+import {
+  AmazonCognitoIdentityJsError,
+  dispatchError,
+} from 'ember-cognito-identity/errors/cognito';
+import { Promise as RSVPPromise } from 'rsvp';
+
+export function getUserSession(
+  cognitoUser: CognitoUser
+): Promise<CognitoUserSession> {
+  let promise: Promise<CognitoUserSession> = new RSVPPromise(
+    (resolve, reject) => {
+      cognitoUser.getSession(
+        (
+          error: AmazonCognitoIdentityJsError | null,
+          cognitoUserSession: CognitoUserSession
+        ) => {
+          if (error) {
+            return reject(dispatchError(error));
+          }
+
+          resolve(cognitoUserSession);
+        },
+        {
+          clientMetadata: {},
+        }
+      );
+    }
+  );
+
+  return waitForPromise(promise);
+}

--- a/addon/utils/cognito/global-sign-out.ts
+++ b/addon/utils/cognito/global-sign-out.ts
@@ -1,0 +1,20 @@
+import { waitForPromise } from '@ember/test-waiters';
+import { CognitoUser } from 'amazon-cognito-identity-js';
+import { dispatchError } from 'ember-cognito-identity/errors/cognito';
+import { Promise as RSVPPromise } from 'rsvp';
+
+export function globalSignOut(cognitoUser: CognitoUser): Promise<void> {
+  let promise: Promise<void> = new RSVPPromise((resolve, reject) => {
+    cognitoUser.globalSignOut({
+      onSuccess: () => {
+        resolve();
+      },
+
+      onFailure(err) {
+        reject(dispatchError(err));
+      },
+    });
+  });
+
+  return waitForPromise(promise);
+}

--- a/addon/utils/cognito/refresh-access-token.ts
+++ b/addon/utils/cognito/refresh-access-token.ts
@@ -1,0 +1,30 @@
+import { waitForPromise } from '@ember/test-waiters';
+import { CognitoUser, CognitoUserSession } from 'amazon-cognito-identity-js';
+import { dispatchError } from 'ember-cognito-identity/errors/cognito';
+import { Promise as RSVPPromise } from 'rsvp';
+
+export async function refreshAccessToken(
+  cognitoUserSession: CognitoUserSession,
+  cognitoUser: CognitoUser
+): Promise<void> {
+  // Note: @types/amazon-cognito-auth-js is incorrectly missing this
+  // @ts-ignore next-line
+  let { refreshToken } = cognitoUserSession;
+
+  if (!refreshToken || !refreshToken.getToken()) {
+    throw new Error('Cannot retrieve a refresh token');
+  }
+
+  let promise: Promise<void> = new RSVPPromise((resolve, reject) => {
+    cognitoUser.refreshSession(refreshToken, (error) => {
+      if (error) {
+        reject(dispatchError(error));
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+  return waitForPromise(promise);
+}

--- a/addon/utils/cognito/set-new-password.ts
+++ b/addon/utils/cognito/set-new-password.ts
@@ -1,0 +1,24 @@
+import { waitForPromise } from '@ember/test-waiters';
+import { CognitoUser } from 'amazon-cognito-identity-js';
+import { dispatchError } from 'ember-cognito-identity/errors/cognito';
+import { Promise as RSVPPromise } from 'rsvp';
+
+export function setNewPassword(
+  cognitoUser: CognitoUser,
+  { newPassword }: { newPassword: string },
+  newAttributes = {}
+): Promise<void> {
+  let promise: Promise<void> = new RSVPPromise((resolve, reject) => {
+    cognitoUser.completeNewPasswordChallenge(newPassword, newAttributes, {
+      onSuccess() {
+        resolve();
+      },
+
+      onFailure(err) {
+        reject(dispatchError(err));
+      },
+    });
+  });
+
+  return waitForPromise(promise);
+}

--- a/addon/utils/cognito/trigger-reset-password-mail.ts
+++ b/addon/utils/cognito/trigger-reset-password-mail.ts
@@ -1,0 +1,22 @@
+import { waitForPromise } from '@ember/test-waiters';
+import { CognitoUser } from 'amazon-cognito-identity-js';
+import { dispatchError } from 'ember-cognito-identity/errors/cognito';
+import { Promise as RSVPPromise } from 'rsvp';
+
+export function triggerResetPasswordMail(
+  cognitoUser: CognitoUser
+): Promise<void> {
+  let promise: Promise<void> = new RSVPPromise((resolve, reject) => {
+    cognitoUser.forgotPassword({
+      onSuccess() {
+        resolve();
+      },
+
+      onFailure(err) {
+        reject(dispatchError(err));
+      },
+    });
+  });
+
+  return waitForPromise(promise);
+}

--- a/addon/utils/cognito/update-password.ts
+++ b/addon/utils/cognito/update-password.ts
@@ -1,0 +1,28 @@
+import { waitForPromise } from '@ember/test-waiters';
+import { CognitoUser } from 'amazon-cognito-identity-js';
+import { dispatchError } from 'ember-cognito-identity/errors/cognito';
+import { Promise as RSVPPromise } from 'rsvp';
+
+export function updatePassword(
+  cognitoUser: CognitoUser,
+  {
+    oldPassword,
+    newPassword,
+  }: {
+    oldPassword: string;
+    newPassword: string;
+  }
+): Promise<void> {
+  let promise: Promise<void> = new RSVPPromise((resolve, reject) => {
+    cognitoUser.changePassword(oldPassword, newPassword, function (error) {
+      if (error) {
+        reject(dispatchError(error));
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+  return waitForPromise(promise);
+}

--- a/addon/utils/cognito/update-reset-password.ts
+++ b/addon/utils/cognito/update-reset-password.ts
@@ -1,0 +1,38 @@
+import { waitForPromise } from '@ember/test-waiters';
+import { CognitoUser } from 'amazon-cognito-identity-js';
+import {
+  AmazonCognitoIdentityJsError,
+  dispatchError,
+} from 'ember-cognito-identity/errors/cognito';
+import { Promise as RSVPPromise } from 'rsvp';
+
+export function updateResetPassword(
+  cognitoUser: CognitoUser,
+  {
+    code,
+    newPassword,
+  }: {
+    code: string;
+    newPassword: string;
+  }
+): Promise<void> {
+  let promise: Promise<void> = new RSVPPromise((resolve, reject) => {
+    cognitoUser.confirmPassword(code, newPassword, {
+      onSuccess() {
+        resolve();
+      },
+
+      onFailure(error: AmazonCognitoIdentityJsError) {
+        // This can also happen, e.g. if the password is shorter than 6 characters
+        if (error.code === 'InvalidParameterException') {
+          error.code = 'InvalidPasswordException';
+          error.name = 'InvalidPasswordException';
+        }
+
+        reject(dispatchError(error));
+      },
+    });
+  });
+
+  return waitForPromise(promise);
+}

--- a/addon/utils/cognito/update-user-attributes.ts
+++ b/addon/utils/cognito/update-user-attributes.ts
@@ -1,0 +1,31 @@
+import { waitForPromise } from '@ember/test-waiters';
+import {
+  CognitoUser,
+  ICognitoUserAttributeData,
+} from 'amazon-cognito-identity-js';
+import {
+  AmazonCognitoIdentityJsError,
+  dispatchError,
+} from 'ember-cognito-identity/errors/cognito';
+import { Promise as RSVPPromise } from 'rsvp';
+
+export function updateUserAttributes(
+  cognitoUser: CognitoUser,
+  attributeList: ICognitoUserAttributeData[]
+) {
+  let promise = new RSVPPromise((resolve, reject) => {
+    cognitoUser.updateAttributes(
+      attributeList,
+      (error: AmazonCognitoIdentityJsError) => {
+        if (error) {
+          reject(dispatchError(error));
+          return;
+        }
+
+        resolve();
+      }
+    );
+  });
+
+  return waitForPromise(promise);
+}

--- a/addon/utils/get-user-attributes.ts
+++ b/addon/utils/get-user-attributes.ts
@@ -1,0 +1,18 @@
+import { CognitoUser } from 'amazon-cognito-identity-js';
+import { getUserData } from './cognito/get-user-data';
+
+export async function getUserAttributes(
+  cognitoUser: CognitoUser
+): Promise<{ [index: string]: string }> {
+  let userData = await getUserData(cognitoUser);
+
+  let userAttributes: { [index: string]: string } = {};
+  userData.UserAttributes.forEach((cognitoUserAttribute) => {
+    let name = cognitoUserAttribute.Name;
+    let value = cognitoUserAttribute.Value;
+
+    userAttributes[name] = value;
+  });
+
+  return userAttributes;
+}

--- a/addon/utils/load-user-data-and-access-token.ts
+++ b/addon/utils/load-user-data-and-access-token.ts
@@ -1,0 +1,41 @@
+import {
+  CognitoUserPool,
+  CognitoUserSession,
+} from 'amazon-cognito-identity-js';
+import { CognitoNotAuthenticatedError } from 'ember-cognito-identity/errors/cognito';
+import {
+  CognitoData,
+  UserAttributes,
+} from 'ember-cognito-identity/services/cognito';
+import { getUserSession } from './cognito/get-user-session';
+import { getUserAttributes } from './get-user-attributes';
+
+export async function loadUserDataAndAccessToken(
+  userPool: CognitoUserPool
+): Promise<CognitoData> {
+  let cognitoUser = userPool.getCurrentUser();
+  if (!cognitoUser) {
+    throw new CognitoNotAuthenticatedError();
+  }
+
+  let cognitoUserSession: CognitoUserSession, userAttributes: UserAttributes;
+
+  try {
+    cognitoUserSession = await getUserSession(cognitoUser);
+    userAttributes = await getUserAttributes(cognitoUser);
+  } catch (error) {
+    cognitoUser.signOut();
+    throw error;
+  }
+
+  let jwtToken = cognitoUserSession.getAccessToken().getJwtToken();
+
+  let cognitoData: CognitoData = {
+    cognitoUser,
+    userAttributes,
+    cognitoUserSession,
+    jwtToken,
+  };
+
+  return cognitoData;
+}

--- a/addon/utils/user-data.ts
+++ b/addon/utils/user-data.ts
@@ -1,0 +1,39 @@
+import { waitForPromise } from '@ember/test-waiters';
+import { CognitoUser, UserData } from 'amazon-cognito-identity-js';
+import { dispatchError } from 'ember-cognito-identity/errors/cognito';
+
+export function getUserData(
+  cognitoUser: CognitoUser,
+  { forceReload = false } = {}
+): Promise<UserData> {
+  let promise: Promise<UserData> = new Promise((resolve, reject) => {
+    cognitoUser.getUserData(
+      (error, userData) => {
+        if (error) {
+          return reject(dispatchError(error));
+        }
+
+        resolve(userData!);
+      },
+      { bypassCache: forceReload }
+    );
+  });
+
+  return waitForPromise(promise);
+}
+
+export async function getUserAttributes(
+  cognitoUser: CognitoUser
+): Promise<any> {
+  let userData = await getUserData(cognitoUser);
+
+  let userAttributes: { [index: string]: string } = {};
+  userData.UserAttributes.forEach((cognitoUserAttribute) => {
+    let name = cognitoUserAttribute.Name;
+    let value = cognitoUserAttribute.Value;
+
+    userAttributes[name] = value;
+  });
+
+  return userAttributes;
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@ember/test-waiters": "^2.3.2",
+    "@embroider/macros": "^0.42.1",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@types/amazon-cognito-auth-js": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4452,15 +4452,10 @@ can-symlink@^1.0.0:
   dependencies:
     tmp "0.0.28"
 
-caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001173:
-  version "1.0.30001176"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001176.tgz#e44bac506d4656bae4944a1417f41597bd307335"
-  integrity sha512-VWdkYmqdkDLRe0lvfJlZQ43rnjKqIGKHWhWWRbkqMsJIUaYDNf/K/sdZZcVO6YKQklubokdkJY+ujArsuJ5cag==
-
-caniuse-lite@^1.0.30001181:
-  version "1.0.30001205"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz#d79bf6a6fb13196b4bb46e5143a22ca0242e0ef8"
-  integrity sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==
+caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001181:
+  version "1.0.30001239"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz"
+  integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,6 +1154,31 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
+"@embroider/macros@^0.42.1":
+  version "0.42.1"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.42.1.tgz#7a0a4b179c14bf37ce493c524d2e9b3c0a4a2950"
+  integrity sha512-1CtE4ZBMzivA+VBCpoLbnqIAaYYfOWBtBACaNNX/ho0rRp5haIWxiR/BWROcGCtgwWPeiD402J9Zw2gPsdOaOw==
+  dependencies:
+    "@embroider/shared-internals" "0.42.1"
+    assert-never "^1.2.1"
+    ember-cli-babel "^7.26.6"
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+    semver "^7.3.2"
+
+"@embroider/shared-internals@0.42.1":
+  version "0.42.1"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.42.1.tgz#22c7c39ea66b9abfdfded5997a4c753521da22f7"
+  integrity sha512-ANTPOsEA77jrIXU39ZKT5FWRt7lu2CZHnrHnSHoZrFANgSdW7TJtVkm1th4DgC2XOhBafFCkF+SR8uOzqJ8W/w==
+  dependencies:
+    ember-rfc176-data "^0.3.17"
+    fs-extra "^9.1.0"
+    lodash "^4.17.21"
+    pkg-up "^3.1.0"
+    resolve-package-path "^4.0.1"
+    semver "^7.3.5"
+    typescript-memoize "^1.0.1"
+
 "@embroider/shared-internals@^0.40.0":
   version "0.40.0"
   resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.40.0.tgz#2f768c60f4f35ba5f9228f046f70324851e8bfe2"
@@ -2634,7 +2659,7 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-assert-never@^1.1.0:
+assert-never@^1.1.0, assert-never@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/assert-never/-/assert-never-1.2.1.tgz#11f0e363bf146205fb08193b5c7b90f4d1cf44fe"
   integrity sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==
@@ -5649,7 +5674,7 @@ ember-cli-babel@^6.0.0-beta.4:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -11832,6 +11857,13 @@ resolve-package-path@^3.1.0:
     path-root "^0.1.1"
     resolve "^1.17.0"
 
+resolve-package-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-4.0.1.tgz#0e77271e06c8cc41740d28ef974806a77fdc8880"
+  integrity sha512-2gb/yU2fSfX22pjDYyevzyOKK9q72XKUFqlAsrfPzZArM4JkIH/Qcme4n3EbaZttObWm/fIFLbPxrXIyiL8wdQ==
+  dependencies:
+    path-root "^0.1.1"
+
 resolve-path@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
@@ -13341,6 +13373,11 @@ typescript-memoize@^1.0.0-alpha.3:
   version "1.0.0-alpha.4"
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.0-alpha.4.tgz#fd97ab63807c3392af5d0ac5f4754254a4fcd634"
   integrity sha512-woA2UUWSvx8ugkEjPN8DMuNjukBp8NQeLmz+LRXbEsQIvhLR8LSlD+8Qxdk7NmgE8xeJabJdU8zSrO4ozijGjg==
+
+typescript-memoize@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.1.tgz#0a8199aa28f6fe18517f6e9308ef7bfbe9a98d59"
+  integrity sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w==
 
 typescript@~4.3.2:
   version "4.3.2"


### PR DESCRIPTION
This PR refactors all the amazon-cognito-identity-js methods (which are callback-based) into util functions that basically wrap those and promisify them.

This makes the central cognito service much smaller and easier to understand/follow, and more extensible.