### PR TITLE
Fix default `enableMocks` config

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
 
     '@embroider/macros': {
       setOwnConfig: {
-        enableMocks: process.env.MOCK_COGNITO !== 'false',
+        enableMocks: Boolean(process.env.MOCK_COGNITO),
         mockUsername: 'jane@example.com',
         mockPassword: 'test1234',
         mockCode: 123456,


### PR DESCRIPTION
Note: There seems to be a bug in @embroider/macros that does not allow you to overwrite an addon's config in an app. 
See: https://github.com/embroider-build/embroider/issues/885

I am working on a PR to fix the issue (hopefully).