### PR TITLE
chore(deps): bump @embroider/macros from 0.42.0 to 0.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ember/test-waiters": "^2.3.2",
-    "@embroider/macros": "^0.42.1",
+    "@embroider/macros": "~0.43.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@types/amazon-cognito-auth-js": "^1.2.2",
@@ -47,7 +47,7 @@
     "@ember/edition-utils": "~1.2.0",
     "@ember/optional-features": "~2.0.0",
     "@ember/test-helpers": "~2.2.5",
-    "@embroider/test-setup": "~0.42.3",
+    "@embroider/test-setup": "~0.43.0",
     "@simple-dom/interface": "~1.4.0",
     "@types/ember": "~3.16.0",
     "@types/ember-qunit": "~3.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,27 +1325,26 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
-"@embroider/macros@^0.42.1":
-  version "0.42.3"
-  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.42.3.tgz#eb4dc35c43f1cb1d14298219ba037f8cead06081"
-  integrity sha512-4I+Sde8FU7QMwNQ3gYtj8fdBTqUeoPDn61XuV4Xng7p9LszQksGDXtyEhWrf9KWU3G+NtrZotY5LICd5P+E3tw==
+"@embroider/macros@~0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.43.0.tgz#d64605cd56b07340b4fefe70906bbe37b54da232"
+  integrity sha512-8F99s5KsGRHTEN8cL8YlHfoErLuWkoGAQjVI436IB4rRhKNLDvnZLkjyuoHkywuwWWaxWZL2q+cjCIZZOPiIoQ==
   dependencies:
-    "@embroider/shared-internals" "0.42.3"
+    "@embroider/shared-internals" "0.43.0"
     assert-never "^1.2.1"
     ember-cli-babel "^7.26.6"
     lodash "^4.17.21"
     resolve "^1.20.0"
     semver "^7.3.2"
 
-"@embroider/shared-internals@0.42.3":
-  version "0.42.3"
-  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.42.3.tgz#65224fe86c55790417078b267add8f54148b59e3"
-  integrity sha512-AIFRumaGxzhzzSswtk97Z0ttu0dyRhXoDuOi6kPYHoprUdtt7biRAksrsbutWWdFapve7vKHFZdYVuiG8IbX0A==
+"@embroider/shared-internals@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.43.0.tgz#b010bc06f1311e3f132098af3191f26e97afb2c2"
+  integrity sha512-YEsH7qkKPECShKkUfE85bezybfPfWxYcHJNWVDrgGFZn7i8IjE7acGhPeh2ydTAJBLisgWTU52b/X92jF54UKQ==
   dependencies:
     ember-rfc176-data "^0.3.17"
     fs-extra "^9.1.0"
     lodash "^4.17.21"
-    pkg-up "^3.1.0"
     resolve-package-path "^4.0.1"
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
@@ -1363,10 +1362,10 @@
     semver "^7.3.2"
     typescript-memoize "^1.0.0-alpha.3"
 
-"@embroider/test-setup@~0.42.3":
-  version "0.42.3"
-  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.42.3.tgz#f314560063d2df928c86b32c71b3f37072fdd570"
-  integrity sha512-iWv1yuZ5MQx/VojbJgererPp+G3WfJ3PS7duD4jEr1DnlwzTuAarjqJI3ljey1UU5Kv3gL1jK99rmi9S8VY1xA==
+"@embroider/test-setup@~0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.43.0.tgz#c549bec9b3597ad30793ba008fcc9f6eafbfa03e"
+  integrity sha512-8LWpqqdPw283yb0LWxbXwf75LTbnpka6kCnTYcFh8MIRR6yraEXNu2BL6xezI5PCbYqc+fhNQGA8gUHbxAOfYw==
   dependencies:
     lodash "^4.17.21"
     resolve "^1.20.0"


### PR DESCRIPTION
Through https://github.com/embroider-build/embroider/pull/888 you should now be able to properly overwrite the macro config in your app.