### PR TITLE
Fix token refreshing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Returns a promise.
 
 ## Token expiration
 
-This addon will automatically refresh the JWT Token every 45 minutes.
+This addon will automatically refresh the JWT Token every 15 minutes before it expires.
 The tokens have a lifespan of 60 minutes, so this should ensure that the local token never experies in the middle of a session.
 
 ## Multi-Factor Authentication (MFA)

--- a/addon/services/cognito.ts
+++ b/addon/services/cognito.ts
@@ -24,6 +24,7 @@ import { triggerResetPasswordMail } from 'ember-cognito-identity/utils/cognito/t
 import { updatePassword } from 'ember-cognito-identity/utils/cognito/update-password';
 import { updateResetPassword } from 'ember-cognito-identity/utils/cognito/update-reset-password';
 import { updateUserAttributes } from 'ember-cognito-identity/utils/cognito/update-user-attributes';
+import { getTokenRefreshWait } from 'ember-cognito-identity/utils/get-token-refresh-wait';
 import { getUserAttributes } from 'ember-cognito-identity/utils/get-user-attributes';
 import { loadUserDataAndAccessToken } from 'ember-cognito-identity/utils/load-user-data-and-access-token';
 import { mockCognitoUser } from 'ember-cognito-identity/utils/mock/cognito-user';
@@ -66,8 +67,6 @@ export default class CognitoService extends Service {
   }
 
   shouldAutoRefresh = !isTesting();
-
-  autoRefreshInterval = 1000 * 60 * 45; // Tokens expire after 1h, so we refresh them every 45 minutes, to have a bit of leeway
 
   _userPool: CognitoUserPool | undefined;
   get userPool(): CognitoUserPool {
@@ -296,7 +295,16 @@ export default class CognitoService extends Service {
 
   @restartableTask
   *_debouncedRefreshAccessToken(): any {
-    yield timeout(this.autoRefreshInterval);
+    assert(
+      'cognitoData is not set, make sure to be authenticated before calling `_debouncedRefreshAccessToken.perform()`',
+      !!this.cognitoData
+    );
+
+    let autoRefreshWait = getTokenRefreshWait(
+      this.cognitoData.cognitoUserSession
+    );
+
+    yield timeout(autoRefreshWait);
 
     try {
       yield this.refreshAccessToken();

--- a/addon/services/cognito.ts
+++ b/addon/services/cognito.ts
@@ -134,7 +134,7 @@ export default class CognitoService extends Service {
     let { cognitoUser, cognitoUserSession } = this.cognitoData!;
 
     await refreshAccessToken(cognitoUserSession, cognitoUser);
-    await loadUserDataAndAccessToken(this.userPool);
+    this.cognitoData = await loadUserDataAndAccessToken(this.userPool);
   }
 
   async authenticate({

--- a/addon/utils/get-token-refresh-wait.ts
+++ b/addon/utils/get-token-refresh-wait.ts
@@ -1,0 +1,16 @@
+import { CognitoUserSession } from 'amazon-cognito-identity-js';
+
+export function getTokenRefreshWait(
+  cognitoUserSession: CognitoUserSession
+): number {
+  let expirationTimestamp = cognitoUserSession.getAccessToken().getExpiration();
+  let now = Math.floor(+new Date() / 1000);
+
+  // We want to refresh 15 minutes before the actual expiration date, to leave some wiggle room
+  let offset = 15 * 60;
+
+  // Fall back to default of 45 mins, if timestamp is not available for whatever reason.
+  return expirationTimestamp
+    ? Math.max(0, expirationTimestamp - now - offset) * 1000
+    : 60 * 45 * 1000;
+}

--- a/addon/utils/mock/cognito-user-session.ts
+++ b/addon/utils/mock/cognito-user-session.ts
@@ -6,11 +6,14 @@ interface Args {
 
 class MockCognitoUserSession {
   #jwtToken = getOwnConfig<any>().mockJwtToken;
+  #expirationDate: Date;
 
   constructor({ jwtToken }: Args = {}) {
     if (jwtToken) {
       this.#jwtToken = jwtToken;
     }
+
+    this.#expirationDate = new Date(+new Date() + 1000 * 60 * 60);
   }
 
   getAccessToken() {
@@ -18,15 +21,23 @@ class MockCognitoUserSession {
       getJwtToken: () => {
         return this.#jwtToken;
       },
+
+      getExpiration: () => {
+        return Math.floor(+this.#expirationDate / 1000);
+      },
     };
   }
 
   get refreshToken() {
     return {
       getToken: () => {
-        return `${this.#jwtToken}-REFRESHED`;
+        return `${this.#jwtToken}-REFRESH`;
       },
     };
+  }
+
+  setExpireIn(seconds: number) {
+    this.#expirationDate = new Date(+new Date() + 1000 * seconds);
   }
 }
 

--- a/addon/utils/mock/cognito-user.ts
+++ b/addon/utils/mock/cognito-user.ts
@@ -157,6 +157,13 @@ class MockCognitoUser {
 
   refreshSession(_: string, callback: (error: null | Error) => void) {
     this.#assert?.step(`cognitoUser.refreshSession()`);
+
+    let jwtToken = `${this.#cognitoUserSession
+      .getAccessToken()
+      .getJwtToken()}-REFRESHED`;
+
+    this.#cognitoUserSession = mockCognitoUserSession({ jwtToken });
+
     callback(null);
   }
 

--- a/tests/unit/utils/get-token-refresh-wait-test.ts
+++ b/tests/unit/utils/get-token-refresh-wait-test.ts
@@ -1,0 +1,79 @@
+import { CognitoUserSession } from 'amazon-cognito-identity-js';
+import { getTokenRefreshWait } from 'ember-cognito-identity/utils/get-token-refresh-wait';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | get-token-refresh-wait', function () {
+  test('it works with missing/empty expiration', function (assert) {
+    let mockSession = {
+      getAccessToken() {
+        return {
+          getExpiration() {
+            return undefined;
+          },
+        };
+      },
+    } as unknown as CognitoUserSession;
+
+    let result = getTokenRefreshWait(mockSession);
+
+    // 45 minutes
+    assert.equal(result, 2700000);
+  });
+
+  test('it works with expiration in the future', function (assert) {
+    let now = new Date();
+
+    let mockSession = {
+      getAccessToken() {
+        return {
+          getExpiration() {
+            return Math.floor(+now / 1000 + 20 * 60);
+          },
+        };
+      },
+    } as unknown as CognitoUserSession;
+
+    let result = getTokenRefreshWait(mockSession);
+
+    // 5 minutes
+    assert.equal(result, 300000);
+  });
+
+  test('it works with expiration in the past', function (assert) {
+    let now = new Date();
+
+    let mockSession = {
+      getAccessToken() {
+        return {
+          getExpiration() {
+            return Math.floor(+now / 1000 - 5 * 60);
+          },
+        };
+      },
+    } as unknown as CognitoUserSession;
+
+    let result = getTokenRefreshWait(mockSession);
+
+    // 5 minutes
+    assert.equal(result, 0);
+  });
+
+  test('it works with expiration in the future, but below margin/threshold', function (assert) {
+    let now = new Date();
+
+    let mockSession = {
+      getAccessToken() {
+        return {
+          getExpiration() {
+            return Math.floor(+now / 1000 + 5 * 60);
+          },
+        };
+      },
+    } as unknown as CognitoUserSession;
+
+    let result = getTokenRefreshWait(mockSession);
+
+    // 5 minutes
+    assert.equal(result, 0);
+  });
+});


### PR DESCRIPTION
The refreshing of JWT tokens was not working correctly.
First, there was a general bug where the token _was_ requested, but not actually set on the cognito service. oops.

Then, there was also a conceptual issue, as we tried to refresh it always 45 mins after setting up the session. However, when the user is already signed in, the token might be older already. We now actually use the expiration date from the token to determine if we need to refresh it. We refresh it 15 minutes before the token expires, to avoid overlap.