### PR TITLE
feat: add `logoutForce` method to allow to handle inconsistent state

### DIFF
--- a/addon/services/cognito.ts
+++ b/addon/services/cognito.ts
@@ -160,6 +160,14 @@ export default class CognitoService extends Service {
     }
   }
 
+  // Only call this if you are in an inconsistent state
+  logoutForce(): void {
+    this.userPool.getCurrentUser()?.signOut();
+    this.cognitoData = null;
+
+    taskFor(this._debouncedRefreshAccessToken).cancelAll();
+  }
+
   invalidateAccessTokens(): Promise<void> {
     assert(
       'cognitoData is not set, make sure to be authenticated before calling `invalidateAccessTokens()`',


### PR DESCRIPTION
Currently, if for whatever reason you end up in an incosistent state, you can potentially not be able to sign out a user.
There is now a `logoutForce` method that will always work, even if there is no cognitoData setup.