### PR TITLE
chore: Use `Object.assign` instead of `assign`

### DIFF
--- a/addon-test-support/helpers/create-jwt-token.ts
+++ b/addon-test-support/helpers/create-jwt-token.ts
@@ -1,11 +1,9 @@
-import { assign } from '@ember/polyfills';
-
 export function createJWTToken(payload: Record<string, any>): string {
   let header = {
     alg: 'RS256',
   };
 
-  let data = assign(
+  let data = Object.assign(
     {
       exp: Math.round(+new Date() / 1000) + 3600,
       iat: Math.round(+new Date() / 1000),


### PR DESCRIPTION
As this is deprecated and not needed anymore.
Note: This has only been used in a test helper, so IE11 support etc. does not really apply anyhow.