### PR TITLE
feat: Ensure licence is correctly MIT

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,9 @@
-Copyright (c) 2019 Fabscale GmbH
+The MIT License (MIT)
 
-This software may not be used by anybody except Fabscale GmbH.
+Copyright (c) 2021
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "repository": "git://github.com/fabscale/ember-cognito-identity.git",
   "author": "Francesco Novy <francesco@fabscale.com>",
+  "license": "MIT",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
This was more on an oversight when moving this from private to public.

Closes https://github.com/fabscale/ember-cognito-identity/issues/671