### PR TITLE
chore(deps): bump amazon-cognito-identity-js from 5.0.3 to 5.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@types/amazon-cognito-auth-js": "^1.2.2",
-    "amazon-cognito-identity-js": "^5.0.3",
+    "amazon-cognito-identity-js": "^5.2.4",
     "ember-auto-import": "^2.2.4",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3480,10 +3480,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-amazon-cognito-identity-js@^5.0.3:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.0.tgz#784c802bc352cbbfd182bef4f6f2a5ab28d7f9f4"
-  integrity sha512-7nRkGb9Cinf1rD5t34B0NDWXO7lmyapXzLmSXq4IBOdiBMrmxToEHcRwfwT2jJfBWzzZiOS0gvQhKI32A+rmvg==
+amazon-cognito-identity-js@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.4.tgz#9b0168a59bd1b933e89b560840f1c50902b87269"
+  integrity sha512-CTRG5LKBfMYmNrqAU0l7X0SA4OOXsPFdHmkW0Ky3NOZZo767W5GZecm5uPz3YyAVde1OHaUyLXYzhXEmnn+VcQ==
   dependencies:
     buffer "4.9.2"
     crypto-js "^4.1.1"


### PR DESCRIPTION
See: https://github.com/aws-amplify/amplify-js/blob/main/packages/amazon-cognito-identity-js/CHANGELOG.md#524-2022-01-07