### PR TITLE
feat: Expose `getAccessToken` and `getIdToken` on `cognitoData`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ let cognitoData = {
   cognitoUserSession: CognitoUserSession,
   jwtToken: 'xxxxx',
   userAttributes: { Email: '...' },
+  getAccessToken: () => CognitoAccessToken,
+  getIdToken: () => CognitoIdToken,
   mfa: {
     enable: () => {},
     disable: () => {},

--- a/addon/services/cognito.ts
+++ b/addon/services/cognito.ts
@@ -5,6 +5,8 @@ import Service, { inject as service } from '@ember/service';
 import { getOwnConfig, isTesting, macroCondition } from '@embroider/macros';
 import { tracked } from '@glimmer/tracking';
 import {
+  CognitoAccessToken,
+  CognitoIdToken,
   CognitoUser,
   CognitoUserPool,
   CognitoUserSession,
@@ -38,6 +40,8 @@ export interface CognitoData {
   userAttributes: UserAttributes;
   cognitoUserSession: CognitoUserSession;
   jwtToken: string;
+  getAccessToken: () => CognitoAccessToken;
+  getIdToken: () => CognitoIdToken;
   mfa: CognitoUserMfa;
 }
 

--- a/addon/utils/load-user-data-and-access-token.ts
+++ b/addon/utils/load-user-data-and-access-token.ts
@@ -36,6 +36,8 @@ export async function loadUserDataAndAccessToken(
     userAttributes,
     cognitoUserSession,
     jwtToken,
+    getAccessToken: () => cognitoUserSession.getAccessToken(),
+    getIdToken: () => cognitoUserSession.getIdToken(),
     mfa: new CognitoUserMfa(cognitoUser),
   };
 

--- a/addon/utils/mock/cognito-data.ts
+++ b/addon/utils/mock/cognito-data.ts
@@ -42,6 +42,8 @@ export function mockCognitoData({
     cognitoUserSession,
     userAttributes,
     jwtToken,
+    getAccessToken: () => cognitoUserSession.getAccessToken(),
+    getIdToken: () => cognitoUserSession.getIdToken(),
     mfa,
   };
 

--- a/addon/utils/mock/cognito-user-session.ts
+++ b/addon/utils/mock/cognito-user-session.ts
@@ -28,6 +28,10 @@ class MockCognitoUserSession {
     };
   }
 
+  getIdToken() {
+    return this.getAccessToken();
+  }
+
   get refreshToken() {
     return {
       getToken: () => {


### PR DESCRIPTION
As shortcuts to `cognitoData.cognitoUserSession.getAccessToken()` and `cognitoData.cognitoUserSession.getIdToken()`:

```js
cognito.cognitoData.getAccessToken();
cognito.cognitoData.getIdToken();
```

Closes https://github.com/fabscale/ember-cognito-identity/issues/723