### PR TITLE
Ensure mock user pool is always correctly set up

### DIFF
--- a/addon/utils/mock/cognito-user-pool.ts
+++ b/addon/utils/mock/cognito-user-pool.ts
@@ -1,15 +1,7 @@
 import { getOwnConfig, macroCondition } from '@embroider/macros';
 
-interface Args {
-  cognitoUser?: any;
-}
-
 class MockCognitoUserPool {
   #cognitoUser: any;
-
-  constructor({ cognitoUser }: Args = {}) {
-    this.#cognitoUser = cognitoUser;
-  }
 
   getCurrentUser() {
     return this.#cognitoUser;
@@ -20,11 +12,9 @@ class MockCognitoUserPool {
   }
 }
 
-export function mockCognitoUserPool(
-  args?: Args
-): MockCognitoUserPool | undefined {
+export function mockCognitoUserPool(): MockCognitoUserPool | undefined {
   if (macroCondition(getOwnConfig<any>().enableMocks)) {
-    return new MockCognitoUserPool(args);
+    return new MockCognitoUserPool();
   }
 
   return undefined;

--- a/addon/utils/mock/cognito-user.ts
+++ b/addon/utils/mock/cognito-user.ts
@@ -2,6 +2,7 @@ import { getOwnConfig, macroCondition } from '@embroider/macros';
 import { CognitoUserSession, UserData } from 'amazon-cognito-identity-js';
 import { AmazonCognitoIdentityJsError } from 'ember-cognito-identity/errors/cognito';
 import { UserAttributes } from 'ember-cognito-identity/services/cognito';
+import { mockCognitoUserPool } from './cognito-user-pool';
 import { mockCognitoUserSession } from './cognito-user-session';
 
 interface Args {
@@ -42,16 +43,18 @@ class MockCognitoUser {
     this.#username = username;
     this.#mfaEnabled = mfaEnabled || false;
     this.#cognitoUserSession = cognitoUserSession || mockCognitoUserSession();
-    this.#userPool = userPool;
+    this.#userPool = userPool || mockCognitoUserPool();
     this.#assert = assert;
   }
 
   signOut() {
     this.#assert?.step('cognitoUser.signOut()');
+    this.#userPool.setCurrentUser(undefined);
   }
 
   globalSignOut(callback: { onSuccess: () => void; onFailure: () => void }) {
     this.#assert?.step('cognitoUser.globalSignOut()');
+    this.#userPool.setCurrentUser(undefined);
     callback.onSuccess();
   }
 

--- a/tests/acceptance/remember-authentication-test.ts
+++ b/tests/acceptance/remember-authentication-test.ts
@@ -124,6 +124,9 @@ module('Acceptance | remember-authentication', function (hooks) {
         assert,
       })!;
 
+      // @ts-ignore
+      cognito.userPool.setCurrentUser(cognito.cognitoData.cognitoUser!);
+
       cognito.cognitoData.cognitoUser.refreshSession = (
         _: any,
         callback: (error: null | AmazonCognitoIdentityJsError) => void

--- a/tests/dummy/app/instance-initializers/mock-cognito.ts
+++ b/tests/dummy/app/instance-initializers/mock-cognito.ts
@@ -4,11 +4,21 @@ import CognitoService from 'ember-cognito-identity/services/cognito';
 import { mockCognitoData } from 'ember-cognito-identity/utils/mock/cognito-data';
 
 export function initialize(appInstance: ApplicationInstance): void {
-  let cognitoData = mockCognitoData();
-  if (cognitoData && !isTesting()) {
-    let cognito = appInstance.lookup('service:cognito') as CognitoService;
-    cognito.cognitoData = cognitoData;
+  if (isTesting()) {
+    return;
   }
+
+  let cognitoData = mockCognitoData();
+
+  if (!cognitoData) {
+    return;
+  }
+
+  let cognito = appInstance.lookup('service:cognito') as CognitoService;
+  cognito.cognitoData = cognitoData;
+
+  // @ts-ignore
+  cognito.userPool.setCurrentUser(cognito.cognitoData.cognitoUser!);
 }
 
 export default {


### PR DESCRIPTION
Otherwise, refreshing a token in mock mode does not work.